### PR TITLE
RED-316 REDSHIFT handle lightning: invoice prefix

### DIFF
--- a/payreq.js
+++ b/payreq.js
@@ -723,6 +723,12 @@ function encode (inputData, addDefaults) {
 // also if anything is hard to read I'll comment.
 function decode (paymentRequest) {
   if (typeof paymentRequest !== 'string') throw new Error('Lightning Payment Request must be string')
+  let lightningPrefix = ''
+  // replace the 'lightning:' without affecting the case of the rest of the string
+  if (paymentRequest.slice(0, 10).toLowerCase() === 'lightning:') {
+    lightningPrefix = paymentRequest.slice(0, 10) // prefix in the original case LiGthNiNg:
+    paymentRequest = paymentRequest.slice(10)
+  }
   if (paymentRequest.slice(0, 2).toLowerCase() !== 'ln') throw new Error('Not a proper lightning payment request')
   let decoded = bech32.decode(paymentRequest, Number.MAX_SAFE_INTEGER)
   paymentRequest = paymentRequest.toLowerCase()
@@ -847,6 +853,8 @@ function decode (paymentRequest) {
   if (timeExpireDate) {
     finalResult = Object.assign(finalResult, {timeExpireDate, timeExpireDateString})
   }
+
+  finalResult.paymentRequest = lightningPrefix.concat(finalResult.paymentRequest)
 
   return orderKeys(finalResult)
 }

--- a/payreq.js
+++ b/payreq.js
@@ -855,7 +855,6 @@ function decode (paymentRequest) {
   }
 
   finalResult.paymentRequest = lightningPrefix.concat(finalResult.paymentRequest)
-
   return orderKeys(finalResult)
 }
 

--- a/test/fixtures.json
+++ b/test/fixtures.json
@@ -714,6 +714,78 @@
   "decode": {
     "valid": [
       {
+        "paymentRequest": "LiGhTnInG:lnbc1pvjluezpp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqdpl2pkx2ctnv5sxxmmwwd5kgetjypeh2ursdae8g6twvus8g6rfwvs8qun0dfjkxaq8rkx3yf5tcsyz3d73gafnh3cax9rn449d9p5uxz9ezhhypd0elx87sjle52x86fux2ypatgddc6k63n7erqz25le42c4u4ecky03ylcqca784w",
+        "coinType": "bitcoin",
+        "prefix": "lnbc",
+        "complete": true,
+        "satoshis": null,
+        "millisatoshis": null,
+        "timestamp": 1496314658,
+        "timestampString": "2017-06-01T10:57:38.000Z",
+        "payeeNodeKey": "03e7156ae33b0a208d0744199163177e909e80176e55d97a2f221ede0f934dd9ad",
+        "signature": "38ec6891345e204145be8a3a99de38e98a39d6a569434e1845c8af7205afcfcc7f425fcd1463e93c32881ead0d6e356d467ec8c02553f9aab15e5738b11f127f",
+        "recoveryFlag": 0,
+        "tags": [
+          {
+            "tagName": "payment_hash",
+            "data": "0001020304050607080900010203040506070809000102030405060708090102"
+          },
+          {
+            "tagName": "description",
+            "data": "Please consider supporting this project"
+          }
+        ],
+        "wordsTemp": "temp1pvjluezpp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqdpl2pkx2ctnv5sxxmmwwd5kgetjypeh2ursdae8g6twvus8g6rfwvs8qun0dfjkxaq8rkx3yf5tcsyz3d73gafnh3cax9rn449d9p5uxz9ezhhypd0elx87sjle52x86fux2ypatgddc6k63n7erqz25le42c4u4ecky03ylcqe49hhl"
+      },           
+      {
+        "paymentRequest": "LIGHTNING:lnbc1pvjluezpp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqdpl2pkx2ctnv5sxxmmwwd5kgetjypeh2ursdae8g6twvus8g6rfwvs8qun0dfjkxaq8rkx3yf5tcsyz3d73gafnh3cax9rn449d9p5uxz9ezhhypd0elx87sjle52x86fux2ypatgddc6k63n7erqz25le42c4u4ecky03ylcqca784w",
+        "coinType": "bitcoin",
+        "prefix": "lnbc",
+        "complete": true,
+        "satoshis": null,
+        "millisatoshis": null,
+        "timestamp": 1496314658,
+        "timestampString": "2017-06-01T10:57:38.000Z",
+        "payeeNodeKey": "03e7156ae33b0a208d0744199163177e909e80176e55d97a2f221ede0f934dd9ad",
+        "signature": "38ec6891345e204145be8a3a99de38e98a39d6a569434e1845c8af7205afcfcc7f425fcd1463e93c32881ead0d6e356d467ec8c02553f9aab15e5738b11f127f",
+        "recoveryFlag": 0,
+        "tags": [
+          {
+            "tagName": "payment_hash",
+            "data": "0001020304050607080900010203040506070809000102030405060708090102"
+          },
+          {
+            "tagName": "description",
+            "data": "Please consider supporting this project"
+          }
+        ],
+        "wordsTemp": "temp1pvjluezpp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqdpl2pkx2ctnv5sxxmmwwd5kgetjypeh2ursdae8g6twvus8g6rfwvs8qun0dfjkxaq8rkx3yf5tcsyz3d73gafnh3cax9rn449d9p5uxz9ezhhypd0elx87sjle52x86fux2ypatgddc6k63n7erqz25le42c4u4ecky03ylcqe49hhl"
+      },         
+      {
+        "paymentRequest": "lightning:lnbc1pvjluezpp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqdpl2pkx2ctnv5sxxmmwwd5kgetjypeh2ursdae8g6twvus8g6rfwvs8qun0dfjkxaq8rkx3yf5tcsyz3d73gafnh3cax9rn449d9p5uxz9ezhhypd0elx87sjle52x86fux2ypatgddc6k63n7erqz25le42c4u4ecky03ylcqca784w",
+        "coinType": "bitcoin",
+        "prefix": "lnbc",
+        "complete": true,
+        "satoshis": null,
+        "millisatoshis": null,
+        "timestamp": 1496314658,
+        "timestampString": "2017-06-01T10:57:38.000Z",
+        "payeeNodeKey": "03e7156ae33b0a208d0744199163177e909e80176e55d97a2f221ede0f934dd9ad",
+        "signature": "38ec6891345e204145be8a3a99de38e98a39d6a569434e1845c8af7205afcfcc7f425fcd1463e93c32881ead0d6e356d467ec8c02553f9aab15e5738b11f127f",
+        "recoveryFlag": 0,
+        "tags": [
+          {
+            "tagName": "payment_hash",
+            "data": "0001020304050607080900010203040506070809000102030405060708090102"
+          },
+          {
+            "tagName": "description",
+            "data": "Please consider supporting this project"
+          }
+        ],
+        "wordsTemp": "temp1pvjluezpp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqdpl2pkx2ctnv5sxxmmwwd5kgetjypeh2ursdae8g6twvus8g6rfwvs8qun0dfjkxaq8rkx3yf5tcsyz3d73gafnh3cax9rn449d9p5uxz9ezhhypd0elx87sjle52x86fux2ypatgddc6k63n7erqz25le42c4u4ecky03ylcqe49hhl"
+      },      
+      {
         "paymentRequest": "lnbc1pvjluezpp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqdpl2pkx2ctnv5sxxmmwwd5kgetjypeh2ursdae8g6twvus8g6rfwvs8qun0dfjkxaq8rkx3yf5tcsyz3d73gafnh3cax9rn449d9p5uxz9ezhhypd0elx87sjle52x86fux2ypatgddc6k63n7erqz25le42c4u4ecky03ylcqca784w",
         "coinType": "bitcoin",
         "prefix": "lnbc",

--- a/test/index.js
+++ b/test/index.js
@@ -146,6 +146,15 @@ fixtures.decode.valid.forEach((f) => {
 
     let signedData3 = lnpayreq.sign(signedData2, fixtures.privateKey)
 
+    // fix encode for prefix 'lightning:' in any case, restores the prefix after encode so same wont fail
+    if (f.paymentRequest.slice(0, 10).toLowerCase() === 'lightning:') {
+      encodedNoPriv.paymentRequest = f.paymentRequest.slice(0, 10).concat(encodedNoPriv.paymentRequest)
+      signedData.paymentRequest = f.paymentRequest.slice(0, 10).concat(signedData.paymentRequest)
+      encodedSignedData.paymentRequest = f.paymentRequest.slice(0, 10).concat(encodedSignedData.paymentRequest)
+      signedData2.paymentRequest = f.paymentRequest.slice(0, 10).concat(signedData2.paymentRequest)
+      signedData3.paymentRequest = f.paymentRequest.slice(0, 10).concat(signedData3.paymentRequest)
+    }
+
     t.same(f, encodedNoPriv)
     t.same(f, signedData)
     t.same(f, encodedSignedData)

--- a/test/index.js
+++ b/test/index.js
@@ -154,7 +154,6 @@ fixtures.decode.valid.forEach((f) => {
       signedData2.paymentRequest = f.paymentRequest.slice(0, 10).concat(signedData2.paymentRequest)
       signedData3.paymentRequest = f.paymentRequest.slice(0, 10).concat(signedData3.paymentRequest)
     }
-
     t.same(f, encodedNoPriv)
     t.same(f, signedData)
     t.same(f, encodedSignedData)


### PR DESCRIPTION
fixes Lightning Network invoices prefixed with `lightning:` being rejected

- [x] Added tests - passing ok